### PR TITLE
Fix the ASCII art diagram to use code blocks and stick to 72 columns

### DIFF
--- a/draft-deen-mops-network-overlay-impacts.md
+++ b/draft-deen-mops-network-overlay-impacts.md
@@ -90,6 +90,18 @@ A popular design choice in privacy enhancements at the IETF has been the encapsu
 
 Along with the use of encrypted connections another popular approach is to additionally create alterative routings and tunnels for connections which bypass the routing and other policy decisions of the ISP access network and of the public open Internet.   These alternative network policy choices have the effect of creating a Network Overlay that operates on top of and over the device\'s Access Network and the Open Internet, but follows an independent set of policies chosen by the Network Overlay.
 
+~~~
+ R  = router
+                    <--- non-overlay traffic path --->
+ device -- R ---- R ------------- R ------------- R ---- R -- dest-node
+            \                                           /
+             \                                         /
+              \                                       /
+               R -- R -- ingest -- egress -- R ------+
+                     <--- overlay traffic path --->
+
+ Figure 1:  Network Overlay routing select traffic via an alternate path
+~~~
 
 ### Partitioning
 Network Overlay policy changes will include an alternate routing policy since a fundamental aspect of this design is the tunneling of connections through alternate paths to enhance privacy. The reasons for this approach are discussed in the IAB document [Partitioning as an Architecture for Privacy](https://datatracker.ietf.org/doc/draft-iab-privacy-partitioning/).


### PR DESCRIPTION
This demonstrates how to use code blocks to do ASCII art. kramdown-rfc also supports other ways to incorporate diagrams. See https://github.com/cabo/kramdown-rfc under "Experimental features".